### PR TITLE
Added a topic change event listener to the node bot

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -105,6 +105,20 @@ zenircbot = {
             zenircbot.pub.publish('in', JSON.stringify(msg));
         });
 
+        bot.addListener('topic', function(channel, topic, nick, message) {
+            console.log(nick + ' changed the topic in ' + channel + ' to "' + topic + '"');
+            var msg = {
+                version: 1,
+                type: 'topic',
+                data: {
+                    sender: nick,
+                    channel: channel,
+                    topic: topic
+                }
+            };
+            zenircbot.pub.publish('in', JSON.stringify(msg));
+        });
+
         bot.addListener('error', function(message) {
             console.log(message);
         });


### PR DESCRIPTION
I needed this in order to make my meme generator service automatically generate a meme on topic change. (https://github.com/thatryana/zenircbot-meme)
