### PR TITLE
Adds 'names' listener to node bot with docs

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -119,6 +119,20 @@ zenircbot = {
             zenircbot.pub.publish('in', JSON.stringify(msg));
         });
 
+        bot.addListener('names', function(channel, nicks) {
+            console.log('Names: '+channel);
+            console.log(nicks);
+            var msg = {
+                version: 1,
+                type: 'names',
+                data: {
+                    channel: channel,
+                    nicks: nicks
+                }
+            };
+            zenircbot.pub.publish('in', JSON.stringify(msg));
+        });
+
         bot.addListener('error', function(message) {
             console.log(message);
         });

--- a/docs/services_devel.rst
+++ b/docs/services_devel.rst
@@ -135,6 +135,24 @@ The possible ``in`` messages.
             }
         }
 
+.. js:data:: "names"
+
+    Sent whenever a list of names is received for a channel::
+
+        {
+            "version": 1,
+            "type": "names",
+            "data": {
+                "channel": "",
+                "nicks": {
+                    "nick": "",
+                    "op_nick": "@"
+                }
+            }
+        }
+
+    This can be triggered by sending a raw command of "NAMES #channel"
+
 Out messages
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
Listens for the "names" IRC messages to get a list of nicks in a channel.
