### PR TITLE
Adds "ping" loop to test for connectivity to server

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -17,12 +17,18 @@ zenircbot = {
         var cfg = zenircbot.server_config_for(0);
         console.log('irc server: '+cfg.hostname+' nick: '+cfg.nick);
         zenircbot.irc = new irc.Client(cfg.hostname, cfg.nick, cfg);
-        var bot = zenircbot.irc
+        var bot = zenircbot.irc;
+
+        var pingLoopActive = false;
 
         bot.addListener('connect', function() {
             zenircbot.pub.set('zenircbot:nick', bot.nick);
             zenircbot.pub.set('zenircbot:admin_spew_channels',
-                              cfg.admin_spew_channels)
+                              cfg.admin_spew_channels);
+            if(pingLoopActive == false) {
+                console.log("Connected, starting PING request loop");
+                newPingRequest();
+            }
         });
 
         bot.addListener('ctcp', function(nick, to, text, type) {
@@ -120,8 +126,7 @@ zenircbot = {
         });
 
         bot.addListener('names', function(channel, nicks) {
-            console.log('Names: '+channel);
-            console.log(nicks);
+            console.log('Names: '+channel + " " + JSON.stringify(nicks));
             var msg = {
                 version: 1,
                 type: 'names',
@@ -146,6 +151,45 @@ zenircbot = {
             var msg = JSON.parse(message);
             output_handlers[msg.version](bot, msg);
         });
+
+        // Set up "ping" timer
+
+        if(true) {
+            var pingRequestPending = false;
+
+            function newPingRequest() {
+                pingLoopActive =  true;
+                console.log("Sending PING");
+                bot.send("PING "+zenircbot.config.servers[0].hostname);
+                pingRequestPending = true;
+                // Set a timeout waiting for the PONG response
+                setTimeout(function(){
+                    if(pingRequestPending) {
+                        // Timer ran before a pong was received. Assume we're disconnected and re-connect.
+                        console.log("Didn't receive PONG in time, reconnecting...");
+                        pingRequestPending = false;
+                        pingLoopActive =  false;
+                        bot.disconnect(function(){
+                            setTimeout(function(){
+                                bot.connect();
+                            }, 3000);                            
+                        });
+                    } else {
+                        console.log("Ping check succeeded. Checking again.");
+                        newPingRequest();
+                    }
+                }, 5000);
+            }
+
+            bot.addListener('raw', function(message) {
+                if(message.command == "PONG") {
+                    pingRequestPending = false;
+                    console.log("Received PONG");
+                }
+            });
+
+        }
+
     },
     unsetRedisKeys: function(){
         zenircbot.pub.del('zenircbot:nick');


### PR DESCRIPTION
Adds a "ping" loop testing for connectivity to the IRC server. If a reply is not received, will attempt to reconnect.

Note that this is not thoroughly tested yet, I've only tested it with some simple connection failure cases such as when the IRC server is completely offline. Still needs to be tested for network degradation failures. 
